### PR TITLE
Change sbatch template to pass mlflow credential variables and make account information optional

### DIFF
--- a/mlflow_slurm/templates/sbatch_template.sh
+++ b/mlflow_slurm/templates/sbatch_template.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 #SBATCH --job-name=MLFlow{{ run_id }}
 #SBATCH --partition={{ config.partition }}
+{% if config.account %}
 #SBATCH --account={{ config.account }}
-#SBATCH --export=MLFLOW_TRACKING_URI,MLFLOW_S3_ENDPOINT_URL,AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
+{% endif %}
+#SBATCH --export=MLFLOW_TRACKING_URI,MLFLOW_TRACKING_USERNAME,MLFLOW_TRACKING_PASSWORD,MLFLOW_S3_ENDPOINT_URL,AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
 {% if config.gpus_per_node %}
 #SBATCH --gpus-per-node={{ config.gpus_per_node }}
 {% endif %}


### PR DESCRIPTION
Hi everyone,
thank you so much for this project, it helps a lot in connecting my mlflow projects to our university's SLURM cluster!

Since our tracking server uses basic auth we need to pass username and password for the tracking server to the job. Further, when setting the account information I ran into configuration errors with our local SLURM config. 
  
Therefore, I added two minor changes to the template: 
- making account information optional
- passing mlflow credential information 

Thanks again and all the best,
Alina