### PR TITLE
Make partition optional

### DIFF
--- a/mlflow_slurm/templates/sbatch_template.sh
+++ b/mlflow_slurm/templates/sbatch_template.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #SBATCH --job-name=MLFlow{{ run_id }}
+{% if config.partition %}
 #SBATCH --partition={{ config.partition }}
+{% endif %}
 {% if config.account %}
 #SBATCH --account={{ config.account }}
 {% endif %}


### PR DESCRIPTION
At Vanderbilt, users have a default partition and aren't required to specify them. If a partition is not provided in the config, then don't pass one to the sbatch script