### PR TITLE
Sequential workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Backend for executing MLFlow projects on Slurm batch system
 
 ## Usage
 Install this package in the environment from which you will be submitting jobs.
-If you are submitting jobs from inside jobs, make sure you have this package 
+If you are submitting jobs from inside jobs, make sure you have this package
 listed in your conda or pip environment.
 
-Just list this as your `--backend` in the job run. You should include a json 
+Just list this as your `--backend` in the job run. You should include a json
 config file to control how the batch script is constructed:
 ```shell
 mlflow run --backend slurm \
@@ -34,7 +34,20 @@ properties in this file are:
 | time              | Max CPU time job may run                                                                                       |
 | sbatch-script-file | Name of batch file to be produced. Leave blank to have service generate a script file name based on the run ID |
 
+## Sequential Worker Jobs
+There are occaisions where you have a job that can't finish in the maxiumum
+allowable wall time. If you are able to write out a checkpoint file, you can
+use sequential worker jobs to continue the job where it left off. This is
+useful for training deep learning models or other long running jobs.
+
+To use this, you just need to provide a parameter to the `mlflow run` command
+```shell
+  mlflow run --backend slurm -c ../../slurm_config.json -P sequential_workers=3 .
+```
+This will the submit the job as normal, but also submit 3 additional jobs that
+each depend on the previous job. As soon as the first job terminates, the next
+job will start. This will continue until all jobs have completed.
+
 ## Development
 The slurm docker deployment is handy for testing and development. You can start
 up a slurm environment with the included docker-compose file
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   slurm:
-    image: giovtorres/docker-centos7-slurm:21.08.0
+    image: giovtorres/docker-centos7-slurm:21.08.6
     hostname: slurmctl
     container_name: slurmctl
     working_dir: /mlflow-slurm

--- a/examples/sequential/MLProject
+++ b/examples/sequential/MLProject
@@ -1,0 +1,5 @@
+python_env: python_env.yaml
+
+entry_points:
+    main:
+        command: "./demo.sh"

--- a/examples/sequential/README.md
+++ b/examples/sequential/README.md
@@ -1,0 +1,11 @@
+# Example of Sequential Worker Jobs
+This simple example shows how to use the `sequential_workers` parameter to submit a job that will be split into multiple jobs that depend on each other.
+
+```shell
+mlflow run --backend slurm -c ../../slurm_config.json -P sequential_workers=3 .
+```
+
+Each job appends to a file named `restart.log` with the time the job is run.
+MLFlow will submit three jobs that depend on each other. As soon as the first job terminates, the next job will start. This will continue until all jobs have completed.
+
+When the jobs are complete, you can check the `restart.log` file to see the order in which the jobs were run.

--- a/examples/sequential/demo.sh
+++ b/examples/sequential/demo.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Hello World"
+sleep 2
+date >> restart.log
+exit 0

--- a/examples/sequential/python_env.yaml
+++ b/examples/sequential/python_env.yaml
@@ -1,0 +1,5 @@
+# Python version required to run the project.
+python: "3.10"
+# Dependencies required to run the project.
+dependencies:
+  - mlflow


### PR DESCRIPTION
Add ability to submit multiple sequential worker jobs.

By setting a Run parameter of sequential_workers we will submit a series of worker jobs where each depends on the previous job's completion. This is only really useful if each job persists the current state of the overall workflow so the next job can pick up where the previous job left off.
