### PR TITLE
Add exports property to the config to add env vars to export to the job

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ properties in this file are:
 
 |Config File Setting| Use                                                                                                            |
 |-------------------|----------------------------------------------------------------------------------------------------------------|
-|partition          | Which Slurm partition should the job run in?                                                                   |
- |account            | What account name to run under                                                                                 |
-| environment       | List of additional environment variables to add to the job
+| partition         | Which Slurm partition should the job run in?                                                                   |
+| environment       | List of additional environment variables to add to the job                                                     |
+| exports           | List of environment variables to export to the job                                                             |
 | gpus_per_node     | On GPU partitions how many GPUs to allocate per node                                                           |
 | gres              | SLURM Generic RESources requests                                                                               |
 | mem               | Amount of memory to allocate to CPU jobs                                                                       |

--- a/mlflow_slurm/templates/sbatch_template.sh
+++ b/mlflow_slurm/templates/sbatch_template.sh
@@ -6,7 +6,7 @@
 {% if config.account %}
 #SBATCH --account={{ config.account }}
 {% endif %}
-#SBATCH --export=MLFLOW_TRACKING_URI,MLFLOW_TRACKING_TOKEN,MLFLOW_TRACKING_USERNAME,MLFLOW_TRACKING_PASSWORD,MLFLOW_S3_ENDPOINT_URL,AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
+#SBATCH --export=MLFLOW_TRACKING_URI,MLFLOW_TRACKING_TOKEN,MLFLOW_TRACKING_USERNAME,MLFLOW_TRACKING_PASSWORD,MLFLOW_S3_ENDPOINT_URL,AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID,{{ config.exports |join(',') }}
 {% if config.gpus_per_node %}
 #SBATCH --gpus-per-node={{ config.gpus_per_node }}
 {% endif %}
@@ -37,7 +37,7 @@ export {{ env }}
 export MLFLOW_RUN_ID={{ run_id }}
 echo "job is starting on `hostname`"
 {% if config.nodes %}
-srun --export=ALL /bin/bash -c '{{ command }}' 
+srun --export=ALL /bin/bash -c '{{ command }}'
 {% else %}
 {{ command }}
 {% endif %}


### PR DESCRIPTION
This pull request includes updates to the documentation and the SLURM job submission script to enhance the handling of environment variables.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28): Added a new property `exports` to the configuration file settings table to list environment variables to export to the job.

SLURM job submission script updates:

* [`mlflow_slurm/templates/sbatch_template.sh`](diffhunk://#diff-cd51c90551fbe1114b2f4de16d4721eacc41b72b8a7832baf21862c961a986e7L9-R9): Modified the `#SBATCH --export` line to include additional environment variables specified in the `exports` configuration.