### PR TITLE
Add exports property to the config to add env vars to export to the job

### DIFF
--- a/mlflow_slurm/templates/sbatch_template.sh
+++ b/mlflow_slurm/templates/sbatch_template.sh
@@ -6,7 +6,7 @@
 {% if config.account %}
 #SBATCH --account={{ config.account }}
 {% endif %}
-#SBATCH --export=MLFLOW_TRACKING_URI,MLFLOW_TRACKING_TOKEN,MLFLOW_TRACKING_USERNAME,MLFLOW_TRACKING_PASSWORD,MLFLOW_S3_ENDPOINT_URL,AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID
+#SBATCH --export=MLFLOW_TRACKING_URI,MLFLOW_TRACKING_TOKEN,MLFLOW_TRACKING_USERNAME,MLFLOW_TRACKING_PASSWORD,MLFLOW_S3_ENDPOINT_URL,AWS_SECRET_ACCESS_KEY,AWS_ACCESS_KEY_ID,{{ config.exports |join(',') }}
 {% if config.gpus_per_node %}
 #SBATCH --gpus-per-node={{ config.gpus_per_node }}
 {% endif %}
@@ -43,7 +43,7 @@ export {{ env }}
 export MLFLOW_RUN_ID={{ run_id }}
 echo "job is starting on `hostname`"
 {% if config.nodes %}
-srun --export=ALL /bin/bash -c '{{ command }}' 
+srun --export=ALL /bin/bash -c '{{ command }}'
 {% else %}
 {{ command }}
 {% endif %}


### PR DESCRIPTION
This pull request includes a change to the `mlflow_slurm/templates/sbatch_template.sh` file. The change enhances the SLURM batch script template by allowing additional environment variables to be exported dynamically based on the configuration.

Enhancements to SLURM batch script:

* [`mlflow_slurm/templates/sbatch_template.sh`](diffhunk://#diff-cd51c90551fbe1114b2f4de16d4721eacc41b72b8a7832baf21862c961a986e7L9-R9): Modified the `#SBATCH --export` line to include additional environment variables specified in the configuration using the `config.exports` parameter.